### PR TITLE
chore: release v0.0.0

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,60 @@
+name: Release Binaries
+
+on:
+  release:
+    types: [published]
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: write
+
+jobs:
+  upload-assets:
+    name: ${{ matrix.target }}
+    if: github.repository_owner == 'oxc-project'
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+          - target: aarch64-unknown-linux-musl
+          - target: aarch64-apple-darwin
+            os: macos-11
+          - target: aarch64-pc-windows-msvc
+            os: windows-2019
+          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
+          - target: x86_64-apple-darwin
+            os: macos-11
+          - target: x86_64-pc-windows-msvc
+            os: windows-2019
+          - target: x86_64-unknown-freebsd
+          - target: universal-apple-darwin
+            os: macos-11
+    runs-on: ${{ matrix.os || 'ubuntu-20.04' }}
+    timeout-minutes: 60
+    steps:
+      - uses: taiki-e/checkout-action@v1
+
+      - name: Install Rust
+        run: rustup update stable --no-self-update
+
+      - uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+
+      - run: echo "RUSTFLAGS=${RUSTFLAGS} -C target-feature=+crt-static" >>"${GITHUB_ENV}"
+        if: contains(matrix.target, '-windows-msvc')
+
+      - run: echo "RUSTFLAGS=${RUSTFLAGS} -C target-feature=+crt-static -C link-self-contained=yes" >>"${GITHUB_ENV}"
+        if: contains(matrix.target, '-linux-musl')
+
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: release-oxc
+          target: ${{ matrix.target }}
+          tar: all
+          zip: windows
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.0](https://github.com/oxc-project/release-oxc/releases/tag/v0.0.0) - 2024-03-31
+
+### Other
+- add release-plz
+- add regenerate changelogs
+- update README.md
+- get commit range from tags
+- update version in cargo.toml
+- rename "changelog" to "update"
+- add changelog generation
+- add just raedy
+- init cli boilerplate
+- init cli
+- init tools
+- init project


### PR DESCRIPTION
## 🤖 New release
* `release-oxc`: 0.0.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.0](https://github.com/oxc-project/release-oxc/releases/tag/v0.0.0) - 2024-03-31

### Other
- add release-plz
- add regenerate changelogs
- update README.md
- get commit range from tags
- update version in cargo.toml
- rename "changelog" to "update"
- add changelog generation
- add just raedy
- init cli boilerplate
- init cli
- init tools
- init project
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).